### PR TITLE
Container slim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 .idea
 .vscode
 /XDG_CACHE_HOME
+.devcontainer.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,14 @@
-FROM python:3.7-alpine
+FROM python:3.7-slim
 LABEL MAINTAINER="Yannic Schencking <info@yannic.io>"
 
 WORKDIR /usr/src/app
 
 COPY ./requirements.txt /usr/src/app
 
-RUN apk --no-cache add --virtual build-env \
-    build-base \
-    libffi-dev \
-    openssl-dev \
-    libxml2-dev \
-    libxslt-dev \
-  && pip install --no-cache-dir -r requirements.txt \
-  && apk del build-env
+RUN apt-get update && \
+    apt-get install -y gcc && \
+    pip install --no-cache-dir -r requirements.txt && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY ./scraper.py /usr/src/app
 COPY immo_scraper /usr/src/app/immo_scraper

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2.4"
+version: "2.2"
 services:
   scraper:
     build: .


### PR DESCRIPTION
@webwurst migrated from Docker image ```python:3.7-alpine``` to ```python:3.7-slim```.
works better with 'Remote SSH' extension on VSCode and is based on the beautiful ```debian:stretch-slim```. 